### PR TITLE
Update x-where-is-node.md

### DIFF
--- a/systems-programming/x-where-is-node.md
+++ b/systems-programming/x-where-is-node.md
@@ -1,6 +1,6 @@
 {% if include.problem %}
 
-Write a program called `wherenode.js` that prints the full path to the version of Node is is run with.
+Write a program called `wherenode.js` that prints the full path to the version of Node it is run with.
 
 {% else %}
 


### PR DESCRIPTION
This PR fixes a typo:  `is is` should be `it is`

Note: redundant with PR #50 